### PR TITLE
Fixes path on Windows for the classpath and libs from the target sdk …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.totalcross</groupId>
     <artifactId>totalcross-maven-plugin</artifactId>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
     <name>totalcross-maven-plugin</name>
     <url>http://maven.apache.org</url>
     <packaging>maven-plugin</packaging>
@@ -37,6 +37,12 @@
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
…to -cp when executing totalcross-sdk.jar inside the Mojo

This is a fix related to the feature described on this commit, which was added on version 1.1.2.