### PR TITLE
updates retrolambda to version 2.5.7 and fix exec problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,16 @@
             <artifactId>plexus-utils</artifactId>
             <version>3.3.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.orfjackal.retrolambda</groupId>
+            <artifactId>retrolambda</artifactId>
+            <version>2.5.7</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/totalcross/TotalCrossRetroLambdaMojo.java
+++ b/src/main/java/com/totalcross/TotalCrossRetroLambdaMojo.java
@@ -39,7 +39,7 @@ public class TotalCrossRetroLambdaMojo extends AbstractMojo {
                 plugin(
                         groupId("net.orfjackal.retrolambda"),
                         artifactId("retrolambda-maven-plugin"),
-                        version("2.5.6")
+                        version("2.5.7")
                 ),
                 goal("process-main"),
                 configuration(


### PR DESCRIPTION
exec-maven-plugin requires the plugin to be specified on pom dependences to work. In addition, I've updated retrolambda to version 2.5.7