### PR TITLE
adds option to create and load totalcross libraries.

### DIFF
--- a/src/main/java/com/totalcross/TCZUtils.java
+++ b/src/main/java/com/totalcross/TCZUtils.java
@@ -1,0 +1,146 @@
+package com.totalcross;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.logging.Logger;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.project.MavenProject;
+
+import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.model.FileHeader;
+import net.lingala.zip4j.model.ZipParameters;
+import net.lingala.zip4j.model.enums.CompressionLevel;
+import net.lingala.zip4j.model.enums.CompressionMethod;
+
+
+
+public class TCZUtils {
+
+    MavenProject mavenProject;
+    private String outputDirectory;
+    ArrayList<String> totalcrossLibs;
+    Logger logger;
+    private String pathToFinalJar;
+
+    TCZUtils (MavenProject mavenProject) {
+        this.mavenProject = mavenProject;
+        this.outputDirectory = mavenProject.getBuild().getDirectory();
+        this.totalcrossLibs = new ArrayList<String>();
+        this.pathToFinalJar = Paths.get(outputDirectory, mavenProject.getBuild().getFinalName() + ".jar")
+            .toAbsolutePath().toString();
+    }
+    
+    /**
+     * If the artifact is a totalcross library, it will extract the library tcz
+     * with name 'artifactId'Lib.tcz to output directory in side totalcross-lib
+     * folder. 
+     * 
+     * @param artifact
+     * @return It returns true, if this library is a totalcross library, otherwise
+     * returns false. 
+     */
+    public boolean extractTCZsFromArtifactDependency(Artifact artifact) {
+        String path = artifact.getFile().getAbsolutePath();
+
+        ZipFile zipFile = new ZipFile(path);
+        String libName = artifact.getArtifactId();
+
+        try {
+            String tczFileName = verifyAndFixLibName(libName) + ".tcz";
+            FileHeader fileHeader = zipFile.getFileHeader(tczFileName);
+            String libDir = Paths.get(outputDirectory, "totalcross-libs").toAbsolutePath().toString();
+            File libDirFile = new File(libDir);
+            libDirFile.mkdirs();
+            
+            if (fileHeader != null) {
+                zipFile.extractFile(tczFileName, libDir);
+                String tczPath = Paths.get(libDir, tczFileName).toAbsolutePath().toString();
+                totalcrossLibs.add(tczPath);
+                return true;
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    /**
+     * Create a all.pkg inside outputdirectory with the paths to all files inside
+     * totalcross-libs at build directory.
+     * @return true if it included at least one library.
+     */
+    public boolean includeTCZLibsOnAllPKG() {
+        if (totalcrossLibs.size() < 1)
+            return false;
+        ZipFile zipFile = new ZipFile(pathToFinalJar);
+
+        try {
+            FileHeader fileHeader = zipFile.getFileHeader("all.pkg");
+
+            String allPKGPath = Paths.get(outputDirectory, "all.pkg").toAbsolutePath().toString();
+            if (fileHeader != null) {
+                zipFile.extractFile("all.pkg", outputDirectory);
+            }
+            File allPKG = new File(allPKGPath);
+            FileOutputStream fos = new FileOutputStream(allPKG, true);
+	        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fos));
+            for (String tczPath : totalcrossLibs) {
+                bw.write("[L]" + tczPath);
+                bw.newLine();
+            }
+            bw.close();
+            fos.close();
+            
+        } catch (IOException e) {
+            e.printStackTrace();
+
+        }
+        return true;
+    }
+
+    /**
+     * TotalCross tcz files are only loaded by the vm as totalcross librarys
+     * when it ends with Lib.tcz, i.e, KnowCodeXMLLib.tcz. This function adds
+     * a Lib, to the end of the word if it doesn't ends with Lib already.
+     * Used to find tcz inside a jar and to create libraries. 
+     * @param libName
+     * @return
+     */
+    static String verifyAndFixLibName (String libName) {
+        if(!libName.substring(libName.length() - 3).equals("Lib")) {
+            return libName + "Lib";
+        }
+        return libName;
+    }
+
+    /**
+     * Add a file to the final build jar
+     * @param path
+     */
+    public void addFileToJar(String path) {
+        addFileToJar(path, pathToFinalJar);
+    }
+
+    /**
+     * Add a file to a zip file.
+     * @param path
+     * @param zipPath
+     */
+    public void addFileToJar(String path, String zipPath) {
+        try {
+            ZipFile zipFile = new ZipFile(zipPath);
+            ZipParameters parameters = new ZipParameters();
+            parameters.setCompressionMethod(CompressionMethod.DEFLATE);
+            parameters.setCompressionLevel(CompressionLevel.NORMAL);
+            zipFile.addFile(new File(path), parameters);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/totalcross/TCZUtils.java
+++ b/src/main/java/com/totalcross/TCZUtils.java
@@ -38,7 +38,7 @@ public class TCZUtils {
     
     /**
      * If the artifact is a totalcross library, it will extract the library tcz
-     * with name 'artifactId'Lib.tcz to output directory in side totalcross-lib
+     * with name 'artifactId'Lib.tcz to output directory inside totalcross-lib
      * folder. 
      * 
      * @param artifact

--- a/src/main/java/com/totalcross/TCZUtils.java
+++ b/src/main/java/com/totalcross/TCZUtils.java
@@ -105,7 +105,7 @@ public class TCZUtils {
     }
 
     /**
-     * TotalCross tcz files are only loaded by the vm as totalcross librarys
+     * TotalCross tcz files are only loaded by the vm as totalcross libraries
      * when it ends with Lib.tcz, i.e, KnowCodeXMLLib.tcz. This function adds
      * a Lib, to the end of the word if it doesn't ends with Lib already.
      * Used to find tcz inside a jar and to create libraries. 

--- a/src/main/java/com/totalcross/TotalCrossMojo.java
+++ b/src/main/java/com/totalcross/TotalCrossMojo.java
@@ -3,6 +3,7 @@ package com.totalcross;
 import com.totalcross.exception.SDKVersionNotFoundException;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.BuildPluginManager;
@@ -12,12 +13,24 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.*;
 import org.apache.maven.project.MavenProject;
 
+import net.lingala.zip4j.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+import net.lingala.zip4j.model.FileHeader;
+import net.lingala.zip4j.model.ZipParameters;
+import net.lingala.zip4j.model.enums.CompressionLevel;
+import net.lingala.zip4j.model.enums.CompressionMethod;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Collection;
 
 import static org.twdata.maven.mojoexecutor.MojoExecutor.*;
+
 @Mojo(name = "package", requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME)
 public class TotalCrossMojo extends AbstractMojo {
 
@@ -28,13 +41,25 @@ public class TotalCrossMojo extends AbstractMojo {
     private String activationKey;
 
     @Parameter
-    private String [] platforms;
+    private String[] platforms;
 
     @Parameter
     private String certificates;
 
     @Parameter
     private String totalcrossHome;
+
+    @Parameter(defaultValue = "${project.build.directory}", required = true)
+    private String outputDirectory;
+
+    @Parameter(defaultValue = "${project.build.finalName}", required = true)
+    private String finalName;
+
+    @Parameter(defaultValue = "${project.packaging}", required = true)
+    private String packaging;
+
+    @Parameter
+    private boolean totalcrossLib;
 
     @Component
     private MavenProject mavenProject;
@@ -58,22 +83,41 @@ public class TotalCrossMojo extends AbstractMojo {
 
     Artifact totalcrossArtifact;
 
+    private ArrayList<String> totalcrossLibs = new ArrayList<String>();
+
+    private TCZUtils tczUtils;
+
     public void execute() throws MojoExecutionException, MojoFailureException {
+        tczUtils = new TCZUtils(mavenProject);
         addDependenciesToClasspath();
         setupSDKPath();
         setupArguments();
         deploy();
+        if (totalcrossLib) {
+            String pathToTCZ = Paths.get(outputDirectory, name + ".tcz").toAbsolutePath().toString();
+            tczUtils.addFileToJar(pathToTCZ);
+        }
     }
 
     private void addDependenciesToClasspath() {
+        getLog().info("┌───────── Adding Dependencies to classPath ──────────┐");
+        int countTCDeps = 0;
         for (Artifact artifact : mavenProject.getArtifacts()) {
             final File file = artifact.getFile();
             projectClassPath += file.getAbsolutePath() + classPathSeparator;
-            if(artifact.getArtifactId().equals("totalcross-sdk")) {
-                totalcrossArtifact = artifact;
+            String output = "│ "+ artifact.getArtifactId() + ".jar";
+            if (tczUtils.extractTCZsFromArtifactDependency(artifact)) {
+                output += " (TotalCross Library)";
+                countTCDeps++;
             }
+            getLog().info(output);
         }
-        projectClassPath = projectClassPath.substring(0, projectClassPath.length() -1); // removes last : or ;
+        tczUtils.includeTCZLibsOnAllPKG();
+        getLog().info("├─────────────────────────────────────────────────────");
+        getLog().info("│ TotalCross Libraries: " + countTCDeps + " | Total: " + mavenProject.getArtifacts().size());
+        getLog().info("└─────────────────────────────────────────────────────┘");
+
+        projectClassPath = projectClassPath.substring(0, projectClassPath.length() - 1); // removes last : or ;
     }
 
     private void setupSDKPath () {
@@ -94,13 +138,13 @@ public class TotalCrossMojo extends AbstractMojo {
 
     private String getJarsInsidePath(String path) {
         String returnPath = "";
-        String[] extensions = {"jar"};
+        String[] extensions = { "jar" };
         Collection<File> files = FileUtils.listFiles(new File(path), extensions, true);
         Iterator<File> iterator = files.iterator();
 
-        while(iterator.hasNext()) {
+        while (iterator.hasNext()) {
             returnPath += iterator.next().getAbsolutePath();
-            if(!iterator.hasNext()) {
+            if (!iterator.hasNext()) {
                 break;
             }
             returnPath += classPathSeparator;
@@ -111,46 +155,56 @@ public class TotalCrossMojo extends AbstractMojo {
     public void setupArguments() throws MojoExecutionException {
         args = new ArrayList<Element>();
         args.add(element("argument", "-cp")); // exec -classpath argument
+        Artifact totalcrossArtifact = mavenProject.getArtifactMap()
+                    .get(ArtifactUtils.versionlessKey("com.totalcross"
+                            , "totalcross-sdk"));
+        sdkVersion = totalcrossArtifact.getVersion();
 
         String requiredClassPath = null;
-        if(totalcrossArtifact.getScope().equals("system")) {
+        if (totalcrossArtifact.getScope().equals("system")) {
             requiredClassPath = projectClassPath + classPathSeparator + getJarsInsidePath(totalcrossHome);
-        }
-        else {
+        } else {
             requiredClassPath = projectClassPath;
         }
         args.add(element("argument", requiredClassPath)); // auto generate a classpath
 
         args.add(element("argument", "tc.Deploy"));
-        args.add(element("argument",
-                "${project.build.directory}/${project.build.finalName}.${project.packaging}"));
+        args.add(element("argument", "${project.build.directory}/${project.build.finalName}.${project.packaging}"));
 
-        if(platforms != null) {
+        if (platforms != null && !totalcrossLib) {
             for (int i = 0; i < platforms.length; i++) { // each platform
                 args.add(element("argument", platforms[i]));
             }
         }
 
         // Add app name
-        args.add(element("argument", "/n"));
-        args.add(element("argument", name));
-        args.add(element("argument", "/p"));
+        if(name != null && !totalcrossLib) {
+            args.add(element("argument", "/n"));
+            args.add(element("argument", name));
+            
+        }
+        else if(totalcrossLib) {
+            args.add(element("argument", "/n"));
+            name = mavenProject.getArtifactId();
+            name = TCZUtils.verifyAndFixLibName(name);
+            args.add(element("argument", name));
+        }
 
+        args.add(element("argument", "/p"));
         // Add activation key
         args.add(element("argument", "/r"));
         args.add(element("argument", activationKey));
 
         // /m parameter
-        if(certificates != null) {
+        if (certificates != null) {
             args.add(element("argument", "/m"));
             args.add(element("argument", certificates));
         }
     }
-    
+
     public void deploy() throws MojoExecutionException {
 
-        Element environmentVariables = element("environmentVariables",
-                    element("TOTALCROSS3_HOME", totalcrossHome));
+        Element environmentVariables = element("environmentVariables", element("TOTALCROSS3_HOME", totalcrossHome));
 
         Element[] elements = new Element[args.size()];
         elements = args.toArray(elements);


### PR DESCRIPTION
adds an option to create a totalcross library (<totalcrossLib>true</totalcrossLib>). If the java dependency is also a totalcross library the plugin extracts the tcz file, placing it on a created all.pkg inside target folder. This makes possible to import totalcross libraries without using the file all.pkg.