### PR TITLE
adds option to add external files to the application package

### DIFF
--- a/src/main/java/com/totalcross/TCZUtils.java
+++ b/src/main/java/com/totalcross/TCZUtils.java
@@ -42,7 +42,7 @@ public class TCZUtils {
     
     /**
      * If the artifact is a totalcross library, it will extract the library tcz
-     * with name 'artifactId'Lib.tcz to output directory in side totalcross-lib
+     * with name 'artifactId'Lib.tcz to output directory inside totalcross-lib
      * folder. 
      * 
      * @param artifact

--- a/src/main/java/com/totalcross/TCZUtils.java
+++ b/src/main/java/com/totalcross/TCZUtils.java
@@ -27,6 +27,10 @@ public class TCZUtils {
     ArrayList<String> totalcrossLibs;
     Logger logger;
     private String pathToFinalJar;
+    /**
+     * additional files to be added to the new all.pkg created at the target folder
+     */
+    private String [] additionalFilePaths;
 
     TCZUtils (MavenProject mavenProject) {
         this.mavenProject = mavenProject;
@@ -38,7 +42,7 @@ public class TCZUtils {
     
     /**
      * If the artifact is a totalcross library, it will extract the library tcz
-     * with name 'artifactId'Lib.tcz to output directory inside totalcross-lib
+     * with name 'artifactId'Lib.tcz to output directory in side totalcross-lib
      * folder. 
      * 
      * @param artifact
@@ -94,6 +98,12 @@ public class TCZUtils {
                 bw.write("[L]" + tczPath);
                 bw.newLine();
             }
+            if(additionalFilePaths != null) {
+                for (String filePath : additionalFilePaths) {
+                    bw.write("[L]" + filePath);
+                    bw.newLine();
+                }
+            }
             bw.close();
             fos.close();
             
@@ -142,5 +152,13 @@ public class TCZUtils {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    public String[] getAdditionalFilePaths() {
+        return additionalFilePaths;
+    }
+
+    public void setAdditionalFilePaths(String[] additionalFilePaths) {
+        this.additionalFilePaths = additionalFilePaths;
     }
 }

--- a/src/main/java/com/totalcross/TotalCrossMojo.java
+++ b/src/main/java/com/totalcross/TotalCrossMojo.java
@@ -44,6 +44,9 @@ public class TotalCrossMojo extends AbstractMojo {
     private String[] platforms;
 
     @Parameter
+    private String[] externalResources;
+
+    @Parameter
     private String certificates;
 
     @Parameter
@@ -89,6 +92,7 @@ public class TotalCrossMojo extends AbstractMojo {
 
     public void execute() throws MojoExecutionException, MojoFailureException {
         tczUtils = new TCZUtils(mavenProject);
+        tczUtils.setAdditionalFilePaths(externalResources);
         addDependenciesToClasspath();
         setupSDKPath();
         setupArguments();


### PR DESCRIPTION
this is a replacement to all.pkg. by using externalResources, you can specify which files out of java folder resources must be inside the package of the final application. Files listed inside externalResources won't be zipped inside the .tcz of the application, the will take place at the root of the application.