### PR TITLE
added sanity check to support short library names

### DIFF
--- a/src/main/java/com/totalcross/TCZUtils.java
+++ b/src/main/java/com/totalcross/TCZUtils.java
@@ -122,7 +122,7 @@ public class TCZUtils {
      * @return
      */
     static String verifyAndFixLibName(String libName) {
-        if (!libName.substring(libName.length() - 3).equals("Lib")) {
+        if (libName.length() < 3 || !libName.endsWith("Lib")) {
             return libName + "Lib";
         }
         return libName;


### PR DESCRIPTION
Added sanity check for libraries with a name shorter than 3 characters and simplified the second statement.
Without this check, if such a library is used (e.g. "h2") the following error occurs:
 Failed to execute goal com.totalcross:totalcross-maven-plugin:2.0.3:package (post-package) on project "projectName": Execution post-package of goal com.totalcross:totalcross-maven-plugin:2.0.3:package failed: String index out of range: -1.
